### PR TITLE
Text shows properly even when global background color is disabled

### DIFF
--- a/userDefineLang.xml
+++ b/userDefineLang.xml
@@ -17,20 +17,20 @@
             <Keywords name="Words4">&gt;</Keywords>
         </KeywordLists>
         <Styles>
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="FFFFFF" fontName="" fontStyle="0" />
-            <WordsStyle name="FOLDEROPEN" styleID="12" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" />
-            <WordsStyle name="FOLDERCLOSE" styleID="13" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" />
-            <WordsStyle name="KEYWORD1" styleID="5" fgColor="00FFFF" bgColor="FFFFFF" fontName="" fontStyle="0" />
-            <WordsStyle name="KEYWORD2" styleID="6" fgColor="8080C0" bgColor="FFFFFF" fontName="" fontStyle="1" />
-            <WordsStyle name="KEYWORD3" styleID="7" fgColor="FFFF00" bgColor="FFFFFF" fontName="" fontStyle="1" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="3F3F3F" fontName="" fontStyle="0" />
+            <WordsStyle name="FOLDEROPEN" styleID="12" fgColor="000000" bgColor="3F3F3F" fontName="" fontStyle="0" />
+            <WordsStyle name="FOLDERCLOSE" styleID="13" fgColor="000000" bgColor="3F3F3F" fontName="" fontStyle="0" />
+            <WordsStyle name="KEYWORD1" styleID="5" fgColor="00FFFF" bgColor="3F3F3F" fontName="" fontStyle="0" />
+            <WordsStyle name="KEYWORD2" styleID="6" fgColor="8080C0" bgColor="3F3F3F" fontName="" fontStyle="1" />
+            <WordsStyle name="KEYWORD3" styleID="7" fgColor="FFFF00" bgColor="3F3F3F" fontName="" fontStyle="1" />
             <WordsStyle name="KEYWORD4" styleID="8" fgColor="808040" bgColor="D5FFD5" fontName="" fontStyle="0" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="800000" bgColor="FFFFFF" fontName="" fontStyle="0" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="80FF00" bgColor="FFFFFF" fontName="" fontStyle="1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="80FF00" bgColor="FFFFFF" fontName="" fontStyle="0" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFFF00" bgColor="FFFFFF" fontName="" fontStyle="1" />
-            <WordsStyle name="DELIMINER1" styleID="14" fgColor="80FFFF" bgColor="FFFFFF" fontName="" fontStyle="0" />
-            <WordsStyle name="DELIMINER2" styleID="15" fgColor="800000" bgColor="FFFFFF" fontName="" fontStyle="1" />
-            <WordsStyle name="DELIMINER3" styleID="16" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="800000" bgColor="3F3F3F" fontName="" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="80FF00" bgColor="3F3F3F" fontName="" fontStyle="1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="80FF00" bgColor="3F3F3F" fontName="" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFFF00" bgColor="3F3F3F" fontName="" fontStyle="1" />
+            <WordsStyle name="DELIMINER1" styleID="14" fgColor="80FFFF" bgColor="3F3F3F" fontName="" fontStyle="0" />
+            <WordsStyle name="DELIMINER2" styleID="15" fgColor="800000" bgColor="3F3F3F" fontName="" fontStyle="1" />
+            <WordsStyle name="DELIMINER3" styleID="16" fgColor="000000" bgColor="3F3F3F" fontName="" fontStyle="0" />
         </Styles>
     </UserLang>
 </NotepadPlus>


### PR DESCRIPTION
bgColor=FFFFFF would render text unreadable if global backgroud color is disabled in the style configurator. Changed to zenburn default 3F3F3F
