### PR TITLE
Adding ~~strikethrough~~ as gray font

### DIFF
--- a/userDefineLang.xml
+++ b/userDefineLang.xml
@@ -2,7 +2,7 @@
     <UserLang name="MarkDown" ext="md markdown" udlVersion="2.1">
         <Settings>
             <Global caseIgnored="yes" allowFoldOfComments="no" foldCompact="no" forcePureLC="0" decimalSeparator="0" />
-            <Prefix Keywords1="yes" Keywords2="yes" Keywords3="yes" Keywords4="yes" Keywords5="yes" Keywords6="no" Keywords7="no" Keywords8="no" />
+            <Prefix Keywords1="yes" Keywords2="yes" Keywords3="yes" Keywords4="yes" Keywords5="yes" Keywords6="yes" Keywords7="no" Keywords8="no" />
         </Settings>
         <KeywordLists>
             <Keywords name="Comments">00# 01 02 03&lt;!-- 04--&gt;</Keywords>
@@ -29,7 +29,7 @@
             <Keywords name="Keywords3">*** ___</Keywords>
             <Keywords name="Keywords4">** __ </Keywords>
             <Keywords name="Keywords5">* _</Keywords>
-            <Keywords name="Keywords6"></Keywords>
+            <Keywords name="Keywords6">~~</Keywords>
             <Keywords name="Keywords7"></Keywords>
             <Keywords name="Keywords8"></Keywords>
             <Keywords name="Delimiters">00[ 01 02] 03` 04 05`</Keywords>
@@ -44,7 +44,7 @@
             <WordsStyle name="KEYWORDS3" fgColor="400080" bgColor="FFFFFF" fontName="" fontStyle="3" nesting="0" />
             <WordsStyle name="KEYWORDS4" fgColor="400080" bgColor="FFFFFF" fontName="" fontStyle="1" nesting="0" />
             <WordsStyle name="KEYWORDS5" fgColor="400080" bgColor="FFFFFF" fontName="" fontStyle="2" nesting="0" />
-            <WordsStyle name="KEYWORDS6" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS6" fgColor="808080" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="KEYWORDS7" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="KEYWORDS8" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="OPERATORS" fgColor="0000FF" bgColor="FFFFFF" fontName="" fontStyle="1" nesting="0" />


### PR DESCRIPTION
Adding keyword for ~~ (two tildes) around text. I don't see a way to do an actual strikethrough style, but I think graying out the text helps somewhat.